### PR TITLE
Input check

### DIFF
--- a/iban.cabal
+++ b/iban.cabal
@@ -41,6 +41,7 @@ test-suite tests
                      , tasty
                      , tasty-hunit
                      , text
+                     , tasty-quickcheck
   hs-source-dirs:      test
   main-is:           Main.hs
   other-modules:     IBANRegistryExamples

--- a/src/Finance/IBAN/Data.hs
+++ b/src/Finance/IBAN/Data.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Finance.IBAN.Data
-  (structures) where
+  (structures, isCompliant) where
 
 import Data.Text (Text)
+import Data.Set (Set, fromList, member)
 
 structures :: [Text]
 structures = [ "AL2!n8!n16!c"
@@ -72,3 +73,15 @@ structures = [ "AL2!n8!n16!c"
              , "KZ2!n3!n13!c"
              , "JO4!a4!n18!c"
              ]
+             
+-- |Checks if character belongs to subset used by IBAN REGISTRY to describe IBAN structure
+isCompliant :: Char -> Bool
+isCompliant = (`member` compliantChars)
+
+compliantChars :: Set Char
+compliantChars = fromList $
+                  ['0'..'9']   -- n
+               ++ ['A'..'Z' ]  -- a
+               ++ ['a' .. 'z'] -- together with `n` and `a` forms `c`
+               ++ [' ']
+               

--- a/src/Finance/IBAN/Internal.hs
+++ b/src/Finance/IBAN/Internal.hs
@@ -14,23 +14,20 @@ module Finance.IBAN.Internal
   ) where
 
 import           Control.Arrow (left)
-import           Data.Char (digitToInt, isDigit, isAsciiLower, isAsciiUpper, toUpper, isAlphaNum)
-import           Data.Either (either)
+import           Data.Char (digitToInt, isDigit, isAsciiLower, isAsciiUpper, toUpper)
 import           Data.Map (Map)
 import qualified Data.Map as M
 import           Data.ISO3166_CountryCodes (CountryCode)
 import           Data.List (foldl')
-import           Data.Maybe (fromMaybe, isNothing)
-import           Data.Monoid ((<>))
+import           Data.Maybe (isNothing)
 import           Data.String (IsString, fromString)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Typeable (Typeable)
 import qualified Finance.IBAN.Data as Data
 import           Text.Read (Lexeme(Ident), Read(readPrec), parens, prec, readMaybe, readPrec, lexP)
-import Control.Monad ((>=>))
 
-data IBAN = IBAN {rawIBAN :: Text}
+newtype IBAN = IBAN {rawIBAN :: Text}
   deriving (Eq, Typeable)
 
 instance IsString IBAN where
@@ -43,8 +40,7 @@ instance Show IBAN where
 instance Read IBAN where
     readPrec = parens $ prec 10 $ do
         Ident "fromString" <- lexP
-        str <- readPrec
-        return (fromString str)
+        fromString <$> readPrec
 
 -- | Get the country of the IBAN
 country :: IBAN -> CountryCode
@@ -110,14 +106,14 @@ parseStructure completeStructure = (cc, structure)
 
     structure = case T.foldl' step (0, False, []) s of
                   (0, False, xs) -> reverse xs
-                  otherwise -> err "invalid"
+                  _              -> err "invalid"
 
     step :: (Int, Bool, [SElement]) -> Char -> (Int, Bool, [SElement])
     step (_,   True,   _ ) '!' = err "unexpected '!'"
     step (cnt, False,  xs) '!' = (cnt, True, xs)
     step (cnt, strict, xs)  c
       | isDigit c               = (cnt*10 + digitToInt c, False, xs)
-      | elem c ("nace"::String) = addElement xs condition cnt strict
+      | c `elem` ("nace"::String) = addElement xs condition cnt strict
       | otherwise               = err $ "unexpected " ++ show c
       where
         condition = case c of
@@ -125,6 +121,7 @@ parseStructure completeStructure = (cc, structure)
                       'a' -> isAsciiUpper
                       'c' -> \c' -> isAsciiUpper c' || isDigit c'
                       'e' -> (== ' ')
+                      _   -> err $ "unexpected " ++ show c
 
     addElement xs repr cnt strict = (0, False, SElement repr cnt strict : xs)
     err details = error $ "IBAN.parseStructure: " <> details <> " in " <> show s

--- a/src/Finance/IBAN/Internal.hs
+++ b/src/Finance/IBAN/Internal.hs
@@ -14,7 +14,7 @@ module Finance.IBAN.Internal
   ) where
 
 import           Control.Arrow (left)
-import           Data.Char (digitToInt, isAlphaNum, isDigit, isAsciiLower, isAsciiUpper, toUpper)
+import           Data.Char (digitToInt, isDigit, isAsciiLower, isAsciiUpper, toUpper, isAlphaNum)
 import           Data.Either (either)
 import           Data.Map (Map)
 import qualified Data.Map as M
@@ -28,6 +28,7 @@ import qualified Data.Text as T
 import           Data.Typeable (Typeable)
 import qualified Finance.IBAN.Data as Data
 import           Text.Read (Lexeme(Ident), Read(readPrec), parens, prec, readMaybe, readPrec, lexP)
+import Control.Monad ((>=>))
 
 data IBAN = IBAN {rawIBAN :: Text}
   deriving (Eq, Typeable)
@@ -84,8 +85,8 @@ parseIBAN str
                     then Right $ IBAN s
                     else Left IBANInvalidStructure
   where
-    s              = T.filter (not . (== ' ')) str
-    wrongChars     = T.any (not . isAlphaNum) s
+    s              = T.filter (/= ' ') str
+    wrongChars     = T.any (not . Data.isCompliant) s
     wrongChecksum  = 1 /= mod97_10 s
 
 checkStructure :: BBANStructure -> Text -> Bool


### PR DESCRIPTION
I noticed, that `parseIBAN` can fail on some inputs with `error`while performing checksum despite characters being checked before any processing. So I decided to make input characters check more narrow by shrinking allowed chars to subset used by structure encoding. So parsing characters, that are not supported by structure spec, will fail with `Left` at precondition check, instead of error during checksum check.
(Also corrected some HLint suggestions)