### PR TITLE
add 🇸🇹, 🇱🇨, 🇺🇦, 🇽🇰, 🇹🇱, and 🇲🇷

### DIFF
--- a/src/Finance/IBAN/Data.hs
+++ b/src/Finance/IBAN/Data.hs
@@ -102,6 +102,8 @@ structures =
     KZ2!n3!n13!c
     JO2!n4!a4!n18!c
     EG2!n4!n4!n17!n
+    ST2!n4!n4!n4!n4!n4!n1!n
+    LC2!n4!a4!n4!n4!n4!n4!n4!n
 |]
 
 ibanStructureByCountry :: CountryCode -> Maybe IBANStructure

--- a/src/Finance/IBAN/Data.hs
+++ b/src/Finance/IBAN/Data.hs
@@ -103,7 +103,12 @@ structures =
     JO2!n4!a4!n18!c
     EG2!n4!n4!n17!n
     ST2!n4!n4!n4!n4!n4!n1!n
-    LC2!n4!a4!n4!n4!n4!n4!n4!n
+    LC2!n4!a4!c4!c4!c4!c4!c4!c
+    UA2!n6!n19!c
+    XK2!n4!n10!n2!n
+    SC2!n4!a2!n2!n16!n3!a
+    TL2!n3!n14!n2!n
+    MR2!n5!n5!n11!n2!n
 |]
 
 ibanStructureByCountry :: CountryCode -> Maybe IBANStructure


### PR DESCRIPTION
This link provides the formats of IBANs for different countries:

https://www.xe.com/nl/ibancalculator/countrylist/

I checked which countries were missing. Most were French oversea territories, but Sao Tome and Saint Lucia were different country codes for the IBAN and missing.

Also found extra countries here: https://github.com/josepmartorell/IBAN_Checker/blob/master/src/iban.json